### PR TITLE
Add GitHub action that builds & uploads slides.tex as a PDF on every push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
-    - name: Github Action for LaTeX
+    - name: Checkout repository
+      uses: actions/checkout@v1
+    - name: Build slides.tex to slides.pdf
       uses: xu-cheng/latex-action@1.0.5
       with:
         root_file: slides.tex
+    - name: Upload slides.pdf as artifact  
+      uses: actions/upload-artifact@master  
+      with:
+        name: slides.pdf
+        path: slides.pdf  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Github Action for LaTeX
+      uses: xu-cheng/latex-action@1.0.5
+      with:
+        root_file: slides.tex


### PR DESCRIPTION
I added a GitHub action that builds the slides.tex file and outputs the PDF as an artifact whenever something is pushed to this repository. This makes it easy to get the slides PDF without setting up a LaTeX environment and building the files manually. I successfully tested the action on the current master, you can see the results in my fork under the _Actions_ tab.

The slides.pdf can be downloaded as follows:

**1. go to Actions:**

![1](https://user-images.githubusercontent.com/9062294/67166750-7bd76800-f392-11e9-81df-c779d07f11d2.png)

**2. select the most recent CI build (or any older one)**

![2](https://user-images.githubusercontent.com/9062294/67166755-885bc080-f392-11e9-84e7-5251fcd2510b.png)

**3. click on the _Artifacts_ button, it shows a link to download the .zip file that contains the slides.pdf**

![3](https://user-images.githubusercontent.com/9062294/67166763-94478280-f392-11e9-9d52-1ee62a151b61.png)

